### PR TITLE
use $HOST instead of $SHORT_HOST

### DIFF
--- a/ssh-agent.plugin.zsh
+++ b/ssh-agent.plugin.zsh
@@ -18,7 +18,7 @@ function _start_agent() {
 }
 
 # Get the filename to store/lookup the environment from
-_ssh_env_cache="$HOME/.ssh/environment-$SHORT_HOST"
+_ssh_env_cache="$HOME/.ssh/environment-${HOST:-$(hostname)}"
 
 # test if agent-forwarding is enabled
 zstyle -b :omz:plugins:ssh-agent agent-forwarding _agent_forwarding


### PR DESCRIPTION
Use `$HOST` instead of `SHORT_HOST` and include a fallback to calling `hostname` if $HOST isn't defined.